### PR TITLE
Add ESLint config and Jest setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Tranch Platform
+
+This repository contains the frontend and backend for the Tranch platform.
+
+## Linting
+
+ESLint is configured at the project root with recommended React rules. To run
+lint checks for the frontend code:
+
+```bash
+cd frontend
+npm run lint
+```
+
+## Testing
+
+A basic Jest configuration using React Testing Library is included in the
+`frontend` package. To execute the tests:
+
+```bash
+cd frontend
+npm test
+```
+

--- a/frontend/babel.config.cjs
+++ b/frontend/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+};

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js']
+};

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0 --resolve-plugins-relative-to .",
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.31.8",
@@ -19,13 +20,21 @@
     "react-router-dom": "^6.8.1"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.23.3",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.3",
+    "babel-jest": "^29.7.0",
     "eslint": "^8.45.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3",
     "vite": "^4.4.5"
   }
 }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Navbar = () => (
+  <nav role="navigation" className="navbar">
+    <h1>Tranch</h1>
+  </nav>
+);
+
+export default Navbar;

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Navbar from './Navbar';
+
+describe('Navbar', () => {
+  test('renders brand text', () => {
+    render(<Navbar />);
+    expect(screen.getByRole('navigation')).toHaveTextContent('Tranch');
+  });
+});


### PR DESCRIPTION
## Summary
- add project-wide ESLint configuration with React rules
- configure Jest and React Testing Library in the frontend
- create a simple Navbar component with a test
- document linting and test commands

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684040f70e0c832b93494e58e5dd2ec2