### PR TITLE
Fix missing modal components and lint config

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {}
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0 --resolve-plugins-relative-to .",
+    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "jest"
   },

--- a/frontend/src/components/DocumentManager.jsx
+++ b/frontend/src/components/DocumentManager.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useApi } from '../hooks/useApi';
 import { formatDate } from '../utils/formatters';
+import { FileIcon, DocumentRequestModal } from "./";
 
 const DocumentManager = ({ dealId, userRole, onUpdate }) => {
   const api = useApi();

--- a/frontend/src/components/DocumentRequestModal.jsx
+++ b/frontend/src/components/DocumentRequestModal.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Modal } from './';
+
+const DocumentRequestModal = ({ onClose, onSubmit }) => {
+  const [documentName, setDocumentName] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit({ document_name: documentName, description });
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Request Document">
+      <form onSubmit={handleSubmit} className="document-request-form">
+        <div className="form-group">
+          <label htmlFor="docName">Document Name</label>
+          <input
+            id="docName"
+            type="text"
+            value={documentName}
+            onChange={(e) => setDocumentName(e.target.value)}
+            className="form-input"
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="description">Description</label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="form-input"
+          />
+        </div>
+        <div className="form-actions">
+          <button type="button" onClick={onClose} className="btn btn-outline">
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary">
+            Submit
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export { DocumentRequestModal };

--- a/frontend/src/components/FileIcon.jsx
+++ b/frontend/src/components/FileIcon.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const fileTypeMap = {
+  pdf: '📄',
+  doc: '📄',
+  docx: '📄',
+  xls: '📊',
+  xlsx: '📊',
+  png: '🖼',
+  jpg: '🖼',
+  jpeg: '🖼',
+  default: '📁'
+};
+
+const FileIcon = ({ type }) => {
+  const key = (type || '').toLowerCase();
+  const icon = fileTypeMap[key] || fileTypeMap.default;
+  return <span className="file-icon" aria-hidden>{icon}</span>;
+};
+
+export { FileIcon };

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -2,3 +2,7 @@ export * from './DocumentManager';
 export * from './Modal';
 export * from './NumberInput';
 export * from './ProtectedRoute';
+
+export * from "./DocumentRequestModal";
+export * from "./FileIcon";
+export { default as Navbar } from "./Navbar";


### PR DESCRIPTION
## Summary
- add FileIcon and DocumentRequestModal components
- export new components and Navbar from components index
- update DocumentManager to use new components
- copy ESLint config into frontend and fix lint script

## Testing
- `npm run lint` *(fails: 260 errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840401757ec832ba80d79de2aeaba36